### PR TITLE
AutoTracker: persist settings — dev_008

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,4 @@
+{
+  "ask_create_structure": true,
+  "top_dir": ""
+}


### PR DESCRIPTION
## Summary
- load/save JSON settings from `settings.json`
- persist `top_dir` and user's choice to skip structure setup

## Testing
- `python3 -m py_compile AutoTracker_GUI-v4.py`
- `python3 AutoTracker_GUI-v4.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2eed9f2a48329816649d15fe1c259