### PR TITLE
AutoTracker: remove VC++ step for Windows ffmpeg install — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -1399,9 +1399,7 @@ class AutoTrackerGUI(tk.Tk):
             prefer_cuda = bool(getattr(self, "use_cuda_build_var", None) and self.use_cuda_build_var.get())
             want_cuda = prefer_cuda if getattr(self, "use_cuda_build_var", None) else has_cuda
             # ffmpeg
-            if getattr(self, "inst_ffmpeg", None) and self.inst_ffmpeg.get():                # Ensure Microsoft Visual C++ Redistributable (x64) is present (needed by COLMAP)
-                _win_ensure_vc_redist(sources_dir, self._log_install)
-
+            if getattr(self, "inst_ffmpeg", None) and self.inst_ffmpeg.get():
                 self._log_install("[INSTALL] ffmpeg (Windows prebuilt)")
                 from urllib.parse import urlsplit
                 archive = sources_dir / Path(urlsplit(ffmpeg_url).path).name


### PR DESCRIPTION
## Summary
- remove redundant Visual C++ redistributable check in Windows ffmpeg installer branch

## Testing
- ⚠️ `python3 AutoTracker_GUI-v4.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f6cddb1c8329890b4e833bd26b9d