### PR TITLE
AutoTracker: add PayPal button translation — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -257,6 +257,7 @@ I18N = {
         "about_title": "Info",
         "about_text": "Basiert auf dem Script von ",
         "about_link": "Polyfjord",
+        "about_paypal_btn": "Spendiere mir einen Kaffee via PayPal",
         "dlg_vcredist_title": "VC++ Runtime fehlt",
         "dlg_vcredist_msg": "Die Microsoft VC++ Runtime scheint zu fehlen. Jetzt installieren?",
         "dlg_vcredist_info": "Die VC++ Runtime von Microsoft muss installiert werden, damit das Script funktioniert, Script wird beendet. Nach Installation der VC++ Runtime das Script erneut ausführen.",
@@ -342,6 +343,7 @@ I18N = {
         "about_title": "Info",
         "about_text": "Based on the script by ",
         "about_link": "Polyfjord",
+        "about_paypal_btn": "Buy me a coffee via PayPal",
         "dlg_vcredist_title": "VC++ runtime missing",
         "dlg_vcredist_msg": "Microsoft VC++ runtime seems missing. Install now?",
         "dlg_vcredist_info": "Microsoft VC++ runtime must be installed for the script to work, script will exit. After installing the VC++ runtime, run the script again.",
@@ -1979,7 +1981,7 @@ class AutoTrackerGUI(tk.Tk):
         txt.tag_bind("link", "<Button-1>", lambda e: webbrowser.open_new_tab(url)); txt.configure(state="disabled")
         btnbar = ttk.Frame(frm); btnbar.pack(fill="x", pady=(8,0))
         donate_url = "https://paypal.me/DanielBAdberg"
-        ttk.Button(btnbar, text="Spendiere mir einen Kaffee", command=lambda: webbrowser.open_new_tab(donate_url)).pack(side="left")
+        ttk.Button(btnbar, text=self.S["about_paypal_btn"], command=lambda: webbrowser.open_new_tab(donate_url)).pack(side="left")
         pat_url = "https://www.patreon.com/polyfjord"
         ttk.Button(btnbar, text="Polyfjords Patreon", command=lambda: webbrowser.open_new_tab(pat_url)).pack(side="left")
         ttk.Button(btnbar, text=self.S.get("installer_close", "Schließen"), command=win.destroy).pack(side="right")


### PR DESCRIPTION
## Summary
- add `about_paypal_btn` to German and English i18n dictionaries
- use localized PayPal label in `_open_about_dialog`

## Testing
- `xvfb-run -a python3 -u - <<'PY'
import tkinter as tk
import importlib.util
spec = importlib.util.spec_from_file_location('autotracker','AutoTracker_GUI-v4.py')
mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
class Dummy(tk.Tk):
    def __init__(self, lang):
        super().__init__()
        self.S = mod.I18N[lang]
for lang in ('de','en'):
    root = Dummy(lang)
    before = set(root.winfo_children())
    mod.AutoTrackerGUI._open_about_dialog(root)
    root.update()
    after = set(root.winfo_children())
    win = list(after - before)[0]
    frm = win.winfo_children()[0]
    btnbar = frm.winfo_children()[1]
    first_btn = btnbar.winfo_children()[0]
    print(lang + ': ' + first_btn['text'])
    win.destroy()
    root.destroy()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b3fc78c88c8329be4a7c23748e0faa