### PR TITLE
AutoTracker: enhance mesh option and dense speed — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -202,7 +202,7 @@ I18N = {
         "jpeg_q": "JPEG-Qualität (-qscale:v):",
         "sift_max": "SiftExtraction.max_image_size:",
         "seq_overlap": "SequentialMatching.overlap:",
-        "mesh_check": "Texturiertes Mesh erzeugen",
+        "mesh_check": "Texturiertes Mesh erzeugen (Dauert sehr lange, benötigt viel Platz auf der Festplatte!)",
         "fps_title": "Frame-Reduktion:",
         "fps_all": "Alle Frames",
         "fps_every": "Jeden",
@@ -289,7 +289,7 @@ I18N = {
         "jpeg_q": "JPEG quality (-qscale:v):",
         "sift_max": "SiftExtraction.max_image_size:",
         "seq_overlap": "SequentialMatching.overlap:",
-        "mesh_check": "Create textured mesh",
+        "mesh_check": "Create textured mesh (takes very long, requires lots of disk space!)",
         "fps_title": "Frame reduction:",
         "fps_all": "All frames",
         "fps_every": "Every",
@@ -1014,7 +1014,7 @@ class AutoTrackerGUI(tk.Tk):
         self.lbl_overlap = ttk.Label(more_opts, text=self.S["seq_overlap"]); self.lbl_overlap.grid(row=0, column=4, sticky="w")
         ttk.Entry(more_opts, width=6, textvariable=self.seq_overlap_var).grid(row=0, column=5, sticky="w", padx=(4, 16))
         self.mesh_var = tk.BooleanVar(value=False)
-        self.cb_mesh = ttk.Checkbutton(more_opts, variable=self.mesh_var, text=self.S["mesh_check"])
+        self.cb_mesh = ttk.Checkbutton(more_opts, variable=self.mesh_var, text=self.S["mesh_check"], wraplength=360)
         self.cb_mesh.grid(row=1, column=0, columnspan=6, sticky="w")
 
         self.fps_mode = tk.StringVar(value="all"); self.every_n_var = tk.StringVar(value="2")
@@ -2003,27 +2003,32 @@ class AutoTrackerGUI(tk.Tk):
         cmd = [colmap, "image_undistorter", "--image_path", img_dir, "--input_path", sparse_dir, "--output_path", out_dir]
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
-    def _colmap_patch_match_stereo(self, colmap, workspace):
-        cmd = [colmap, "patch_match_stereo", "--workspace_path", workspace]
+    def _colmap_patch_match_stereo(self, colmap, workspace, max_img, use_gpu):
+        cmd = [colmap, "patch_match_stereo", "--workspace_path", workspace,
+               "--PatchMatchStereo.max_image_size", str(max_img),
+               "--PatchMatchStereo.use_gpu", "1" if use_gpu else "0"]
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
-    def _colmap_stereo_fusion(self, colmap, workspace, out_path):
-        cmd = [colmap, "stereo_fusion", "--workspace_path", workspace, "--output_path", out_path]
+    def _colmap_stereo_fusion(self, colmap, workspace, out_path, cpu_cores):
+        cmd = [colmap, "stereo_fusion", "--workspace_path", workspace, "--output_path", out_path,
+               "--StereoFusion.num_threads", str(cpu_cores)]
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
-    def _colmap_poisson_mesher(self, colmap, in_path, out_path):
-        cmd = [colmap, "poisson_mesher", "--input_path", in_path, "--output_path", out_path]
+    def _colmap_poisson_mesher(self, colmap, in_path, out_path, cpu_cores):
+        cmd = [colmap, "poisson_mesher", "--input_path", in_path, "--output_path", out_path,
+               "--PoissonMesher.num_threads", str(cpu_cores)]
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
-    def _colmap_texture_mesh(self, colmap, in_path, img_dir, out_path):
-        cmd = [colmap, "texture_mesher", "--input_path", in_path, "--image_path", img_dir, "--output_path", out_path]
+    def _colmap_texture_mesh(self, colmap, in_path, img_dir, out_path, cpu_cores):
+        cmd = [colmap, "texture_mesher", "--input_path", in_path, "--image_path", img_dir, "--output_path", out_path,
+               "--TextureMesher.num_threads", str(cpu_cores)]
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
     def _run_pipeline(self, videos, ffmpeg, colmap, glomap):
         try:
             scenes_dir = Path(self.scenes_dir_var.get()); scenes_dir.mkdir(parents=True, exist_ok=True)
             overlap = int(self.seq_overlap_var.get().strip() or "15"); max_img = int(self.sift_max_img_var.get().strip() or "4096")
-            use_gpu = bool(self.use_gpu_var.get())
+            use_gpu = bool(self.use_gpu_var.get()); cpu_cores = os.cpu_count() or 1
             for i, video in enumerate(videos, start=1):
                 if self._stop_flag: break
                 vpath = Path(video); base = vpath.stem
@@ -2055,27 +2060,31 @@ class AutoTrackerGUI(tk.Tk):
                     self._colmap_model_converter(colmap, str(sub0), str(sub0)); self._colmap_model_converter(colmap, str(sub0), str(sparse_dir))
                     if self.mesh_var.get():
                         dense_dir = scene_dir / "dense"; dense_dir.mkdir(parents=True, exist_ok=True)
-                        self.log_line("[dense] image_undistorter…")
-                        code = self._colmap_image_undistorter(colmap, str(img_dir), str(sub0), str(dense_dir))
-                        if code == 0:
-                            self.log_line("[dense] patch_match_stereo…")
-                            code = self._colmap_patch_match_stereo(colmap, str(dense_dir))
-                        if code == 0:
-                            fused = dense_dir / "fused.ply"
-                            self.log_line("[dense] stereo_fusion…")
-                            code = self._colmap_stereo_fusion(colmap, str(dense_dir), str(fused))
-                        if code == 0:
-                            mesh_p = dense_dir / "meshed.ply"
-                            self.log_line("[dense] poisson_mesher…")
-                            code = self._colmap_poisson_mesher(colmap, str(fused), str(mesh_p))
-                        if code == 0:
-                            textured = scene_dir / "textured.ply"
-                            self.log_line("[dense] texture_mesher…")
-                            code = self._colmap_texture_mesh(colmap, str(mesh_p), str(img_dir), str(textured))
+                        fused = dense_dir / "fused.ply"; mesh_p = dense_dir / "meshed.ply"; textured = scene_dir / "textured.ply"
+                        try:
+                            self.log_line("[dense] image_undistorter…")
+                            code = self._colmap_image_undistorter(colmap, str(img_dir), str(sub0), str(dense_dir))
                             if code == 0:
-                                self.log_line(f"[dense] Mesh gespeichert: {textured.name}")
-                        if code != 0:
-                            self.log_line(f"[ERROR] Dense-Rekonstruktion fehlgeschlagen für {base}.")
+                                self.log_line("[dense] patch_match_stereo…")
+                                code = self._colmap_patch_match_stereo(colmap, str(dense_dir), max_img, use_gpu)
+                            if code == 0:
+                                self.log_line("[dense] stereo_fusion…")
+                                code = self._colmap_stereo_fusion(colmap, str(dense_dir), str(fused), cpu_cores)
+                            if code == 0:
+                                self.log_line("[dense] poisson_mesher…")
+                                code = self._colmap_poisson_mesher(colmap, str(fused), str(mesh_p), cpu_cores)
+                            if code == 0:
+                                self.log_line("[dense] texture_mesher…")
+                                code = self._colmap_texture_mesh(colmap, str(mesh_p), str(img_dir), str(textured), cpu_cores)
+                                if code == 0:
+                                    self.log_line(f"[dense] Mesh gespeichert: {textured.name}")
+                            if code != 0:
+                                self.log_line(f"[ERROR] Dense-Rekonstruktion fehlgeschlagen für {base}.")
+                        finally:
+                            for p in (fused, mesh_p):
+                                try: p.unlink()
+                                except Exception: pass
+                            shutil.rmtree(dense_dir, ignore_errors=True)
                 self.log_line(f"✓ Fertig: {base}  ({i}/{len(videos)})"); self._advance_progress(i, len(videos))
             self.log_line("\\n" + self.S["done_all"])
         except Exception as e:


### PR DESCRIPTION
## Summary
- warn users about time and disk cost of textured meshes in DE/EN labels
- wrap mesh checkbox text and forward GPU/CPU limits to COLMAP dense tools
- clean up dense reconstruction temp files to reduce disk usage

## Testing
- `python3 -m py_compile AutoTracker_GUI-v4.py`
- `python3 AutoTracker_GUI-v4.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b0ffcc848329b65c5631f7ac8864