### PR TITLE
AutoTracker: use tk.Checkbutton for mesh option — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -1014,7 +1014,10 @@ class AutoTrackerGUI(tk.Tk):
         self.lbl_overlap = ttk.Label(more_opts, text=self.S["seq_overlap"]); self.lbl_overlap.grid(row=0, column=4, sticky="w")
         ttk.Entry(more_opts, width=6, textvariable=self.seq_overlap_var).grid(row=0, column=5, sticky="w", padx=(4, 16))
         self.mesh_var = tk.BooleanVar(value=False)
-        self.cb_mesh = ttk.Checkbutton(more_opts, variable=self.mesh_var, text=self.S["mesh_check"], wraplength=360)
+        self.cb_mesh = tk.Checkbutton(
+            more_opts, variable=self.mesh_var,
+            text=self.S["mesh_check"], wraplength=360, anchor="w", justify="left"
+        )
         self.cb_mesh.grid(row=1, column=0, columnspan=6, sticky="w")
 
         self.fps_mode = tk.StringVar(value="all"); self.every_n_var = tk.StringVar(value="2")


### PR DESCRIPTION
## Summary
- replace ttk.Checkbutton with tk.Checkbutton so mesh checkbox supports anchor/justify

## Testing
- `xvfb-run -a timeout 5s python AutoTracker_GUI-v4.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5b5baec0c8329b853d2b2d21ae674