### PR TITLE
AutoTracker: switch patch_match_stereo to gpu_index — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -2007,9 +2007,11 @@ class AutoTrackerGUI(tk.Tk):
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
     def _colmap_patch_match_stereo(self, colmap, workspace, max_img, use_gpu):
+        # Use gpu_index (0 for enabled GPU, -1 for CPU fallback) since
+        # PatchMatchStereo.use_gpu is deprecated in recent COLMAP versions.
         cmd = [colmap, "patch_match_stereo", "--workspace_path", workspace,
                "--PatchMatchStereo.max_image_size", str(max_img),
-               "--PatchMatchStereo.use_gpu", "1" if use_gpu else "0"]
+               "--PatchMatchStereo.gpu_index", "0" if use_gpu else "-1"]
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
     def _colmap_stereo_fusion(self, colmap, workspace, out_path, cpu_cores):


### PR DESCRIPTION
## Summary
- replace deprecated PatchMatchStereo.use_gpu with PatchMatchStereo.gpu_index

## Testing
- `colmap patch_match_stereo --help` *(fails: Dense stereo reconstruction requires CUDA)*
- `python3 - <<'PY' ...` *(fails: Dense stereo reconstruction requires CUDA)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b862d340832998b7636fc2b545b5