### PR TITLE
AutoTracker: fix PoissonMeshing thread option — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -2021,7 +2021,7 @@ class AutoTrackerGUI(tk.Tk):
 
     def _colmap_poisson_mesher(self, colmap, in_path, out_path, cpu_cores):
         cmd = [colmap, "poisson_mesher", "--input_path", in_path, "--output_path", out_path,
-               "--PoissonMesher.num_threads", str(cpu_cores)]
+               "--PoissonMeshing.num_threads", str(cpu_cores)]  # use correct option name
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
     def _colmap_texture_mesh(self, colmap, in_path, img_dir, out_path, cpu_cores):


### PR DESCRIPTION
## Summary
- fix PoissonMeshing thread parameter name in `AutoTracker_GUI-v4.py`

## Testing
- `colmap poisson_mesher --help | head -n 40`
- `colmap poisson_mesher --input_path /tmp/dummy --output_path /tmp/dummy --PoissonMeshing.num_threads 1`
- `python3 -m py_compile AutoTracker_GUI-v4.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5d7927ec883298700baf57311fbd6