### PR TITLE
AutoTracker: remove PoissonMeshing thread option — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -2020,8 +2020,7 @@ class AutoTrackerGUI(tk.Tk):
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
     def _colmap_poisson_mesher(self, colmap, in_path, out_path, cpu_cores):
-        cmd = [colmap, "poisson_mesher", "--input_path", in_path, "--output_path", out_path,
-               "--PoissonMeshing.num_threads", str(cpu_cores)]  # use correct option name
+        cmd = [colmap, "poisson_mesher", "--input_path", in_path, "--output_path", out_path]  # thread option removed
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
     def _colmap_texture_mesh(self, colmap, in_path, img_dir, out_path, cpu_cores):


### PR DESCRIPTION
## Summary
- drop deprecated `--PoissonMeshing.num_threads` from `_colmap_poisson_mesher`

## Testing
- `colmap poisson_mesher --help` *(fails: command not found)*
- `python3 AutoTracker_GUI-v4.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ddda60ac832984dc3f3fd28e5096