### PR TITLE
AutoTracker: guard texrecon call for dense meshing — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -2023,9 +2023,11 @@ class AutoTrackerGUI(tk.Tk):
         cmd = [colmap, "poisson_mesher", "--input_path", in_path, "--output_path", out_path]  # thread option removed
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
-    def _colmap_texture_mesh(self, colmap, in_path, img_dir, out_path, cpu_cores):
-        cmd = [colmap, "texture_mesher", "--input_path", in_path, "--image_path", img_dir, "--output_path", out_path,
-               "--TextureMesher.num_threads", str(cpu_cores)]
+    def _texrecon_texture_mesh(self, colmap, in_path, img_dir, out_path, cpu_cores):
+        texrecon = Path(colmap).with_name("texrecon" + Path(colmap).suffix)
+        if not texrecon.exists():
+            self.log_line(f"[ERROR] texrecon nicht gefunden: {texrecon}"); return 1
+        cmd = [str(texrecon), "--max-threads", str(cpu_cores), in_path, img_dir, out_path]  # Parameter mit `texrecon --help` prüfen
         self.log_line(" ".join(shlex.quote(c) for c in cmd)); return run_cmd(cmd, log_fn=self.log_line)
 
     def _run_pipeline(self, videos, ffmpeg, colmap, glomap):
@@ -2079,7 +2081,7 @@ class AutoTrackerGUI(tk.Tk):
                                 code = self._colmap_poisson_mesher(colmap, str(fused), str(mesh_p), cpu_cores)
                             if code == 0:
                                 self.log_line("[dense] texture_mesher…")
-                                code = self._colmap_texture_mesh(colmap, str(mesh_p), str(img_dir), str(textured), cpu_cores)
+                                code = self._texrecon_texture_mesh(colmap, str(mesh_p), str(dense_dir / "images"), str(textured), cpu_cores)
                                 if code == 0:
                                     self.log_line(f"[dense] Mesh gespeichert: {textured.name}")
                             if code != 0:


### PR DESCRIPTION
## Summary
- check for `texrecon` binary before texturing and log a clear error if missing
- feed `texrecon` the undistorted `dense/images` directory for proper texturing

## Testing
- `python -m py_compile AutoTracker_GUI-v4.py`
- `python AutoTracker_GUI-v4.py` *(fails: no display)*
- `python - <<'PY' import importlib.util; spec = importlib.util.spec_from_file_location('at','AutoTracker_GUI-v4.py'); mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); class Dummy:\n    def log_line(self,msg): print(msg)\nfake=Dummy(); code=mod.AutoTrackerGUI._texrecon_texture_mesh(fake,'/usr/bin/colmap','mesh.ply','imgs','out.ply',4); print('exit',code)\nPY` *(texrecon missing logs "[ERROR] texrecon nicht gefunden" and returns exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e3a2d8d88329b9705d551db09593