### PR TITLE
AutoTracker: skip adding processed videos on load — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -1910,11 +1910,14 @@ class AutoTrackerGUI(tk.Tk):
     def load_existing_videos(self):
         # scan project video directory and add found files once
         vids_dir = Path(self.top_dir_var.get()) / DEFAULT_DIRS["videos"]
+        scenes_dir = Path(self.top_dir_var.get()) / DEFAULT_DIRS["scenes"]
         exts = {".mp4", ".mov", ".avi", ".mkv", ".m4v", ".wmv", ".mpg", ".mpeg"}
         if vids_dir.exists():
             existing = set(self.video_list.get(0, "end"))
             for f in vids_dir.iterdir():
                 if f.is_file() and f.suffix.lower() in exts:
+                    if (scenes_dir / f.stem).exists():
+                        continue  # skip videos with an existing scene directory
                     p = str(f)
                     if p not in existing:
                         self.video_list.insert("end", p)


### PR DESCRIPTION
## Summary
- avoid auto-listing videos that already have matching scene directories

## Testing
- `python3 AutoTracker_GUI-v4.py` *(fails: no display name and no $DISPLAY environment variable)*

## Manual QA
1. Create/select project folder with `02 VIDEOS/foo.mp4` and `04 SCENES/foo/` present.
2. Start app or switch project folder.
3. Verify `foo.mp4` no longer auto-appears in the video list while other unprocessed videos do.


------
https://chatgpt.com/codex/tasks/task_e_68c19881d1b483299d15a78765457409