### PR TITLE
AutoTracker: Tkinter ImportError Handling erweitert — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -402,7 +402,7 @@ def _sudo_wrap(cmd):
 def ensure_tkinter():
     try:
         import importlib; importlib.import_module("tkinter"); return True
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, ImportError):  # also catch missing shared libs raising ImportError
         if OS_NAME != "Linux":
             sys.stderr.write("[Error] Tkinter missing and cannot be auto-installed on this OS.\n")
             return False
@@ -423,7 +423,7 @@ def ensure_tkinter():
             try:
                 import importlib; importlib.import_module("tkinter")
                 os.execv(sys.executable, [sys.executable] + sys.argv)
-            except ModuleNotFoundError:
+            except (ModuleNotFoundError, ImportError):  # handle libtk import failures as well
                 sys.stderr.write("Tkinter still cannot be imported.\n")
                 return False
         else:


### PR DESCRIPTION
## Summary
- AutoTracker_GUI-v4.py: ensure_tkinter – Linux-Importfehler (ModuleNotFoundError/ImportError) gleichermaßen abfangen, damit libtk-Bibliotheksprobleme den Installer auslösen.

## Testing
- python3 -m compileall AutoTracker_GUI-v4.py
- CachyOS/Arch Starttest konnte in dieser Umgebung mangels entsprechender Distribution nicht durchgeführt werden; Logik bleibt ansonsten unverändert und Windows-Pfade unberührt.


------
https://chatgpt.com/codex/tasks/task_e_68cfed26bc8c83299c059b4ecb9b19f6