### PR TITLE
AutoTracker: enforce noninteractive AUR helper run — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -1358,7 +1358,7 @@ class AutoTrackerGUI(tk.Tk):
             aur_helper = which_first(["yay", "paru"])  # finde verfügbaren AUR-Helper für eine mögliche Automatisierung
             if aur_helper and self._ask_aur_helper_permission(aur_helper, missing):
                 helper_name = Path(aur_helper).name
-                cmd = [aur_helper, "-S", "--needed", *missing]
+                cmd = [aur_helper, "-S", "--needed", "--noconfirm", *missing]
                 self._log_install(f"[pacman] Starte {helper_name} für fehlende Pakete: {' '.join(missing)}")
                 try:
                     proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)


### PR DESCRIPTION
## Summary
- AutoTracker_GUI-v4.py :: _ensure_pacman_repo_packages (L1361) ergänzt den AUR-Helper-Aufruf um `--noconfirm`, damit `yay/paru` weiterhin `--needed` behalten und ohne Rückfragen durchlaufen.

## QA
- OS: Ubuntu 22.04 (Container)
- Befehl: `python3 -m py_compile AutoTracker_GUI-v4.py` – Syntaxprüfung erfolgreich.
- Hinweis: Der CachyOS/Arch-AUR-Helperpfad konnte in dieser Umgebung nicht praktisch geprüft werden; erwartet wird ein durchlaufender Helper ohne weitere Prompts, woraufhin das Skript wieder in den normalen Installationsfluss eintritt.

Windows-Logik wurde nicht verändert.


------
https://chatgpt.com/codex/tasks/task_e_68cffd1c6b7083299749ebff4d72c3b0