### PR TITLE
AutoTracker: ensure aur prereqs before helper — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -1381,6 +1381,13 @@ class AutoTrackerGUI(tk.Tk):
                 missing.append(name)
         if missing:
             self._log_install(f"[pacman] Pakete nicht in aktivierten Repositories gefunden: {' '.join(missing)}")
+            # Sorge dafür, dass grundlegende Build-Werkzeuge vor dem AUR-Helper verfügbar sind.
+            prereqs = [name for name in ("base-devel", "git") if name in pkgs]
+            if prereqs:
+                self._log_install(f"[pacman] Stelle Build-Voraussetzungen für AUR bereit: {' '.join(prereqs)}")
+                if pkg_install("pacman", prereqs, self._log_install) != 0:
+                    self._log_install("[pacman] Installation der Build-Voraussetzungen fehlgeschlagen – Installer abgebrochen.")
+                    return False
             aur_helper = which_first(["yay", "paru"])  # finde verfügbaren AUR-Helper für eine mögliche Automatisierung
             if aur_helper and self._ask_aur_helper_permission(aur_helper, missing):
                 helper_name = Path(aur_helper).name


### PR DESCRIPTION
## Summary
- AutoTracker_GUI-v4.py — _ensure_pacman_repo_packages (ca. L1381-L1387): install pacman build prerequisites via pkg_install before invoking yay/paru so AUR builds can proceed.

## Testing
- python -m compileall AutoTracker_GUI-v4.py (Ubuntu container)
- Not run: Windows GUI/installer (environment not available)

Windows-spezifische Logik bleibt unverändert.


------
https://chatgpt.com/codex/tasks/task_e_68d009ebe9488329bcf52a3a150006b6