### PR TITLE
AutoTracker: pacman repo check respects installed packages — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -1375,6 +1375,16 @@ class AutoTrackerGUI(tk.Tk):
             if collect_only:
                 self._pending_pacman_repo_packages = []
             return True
+        try:
+            still_missing = pkg_missing("pacman", to_check, self._log_install)
+        except Exception as exc:
+            self._log_install(f"[pacman] Lokale Paketprüfung für {' '.join(to_check)} fehlgeschlagen: {exc}")
+            still_missing = to_check
+        if not still_missing:
+            if collect_only:
+                self._pending_pacman_repo_packages = []
+            return True
+        to_check = still_missing
         missing = []
         for name in to_check:
             try:


### PR DESCRIPTION
## Summary
- AutoTracker_GUI-v4.py — _ensure_pacman_repo_packages — L1365-L1387: prüft per pkg_missing, ob die Zielpakete bereits installiert sind, bevor eine Repo-Suche/AUR-Hilfestart erfolgt.

## Testing
- Ubuntu 22.04 (Container): `python -m compileall AutoTracker_GUI-v4.py` → erzeugt Bytecode ohne Fehler.

Windows-Logik wurde nicht verändert.

------
https://chatgpt.com/codex/tasks/task_e_68d01e5adb188329b6db5659865895f6