### PR TITLE
AutoTracker: rerun pacman repo guard before batch install — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -1948,11 +1948,15 @@ class AutoTrackerGUI(tk.Tk):
                     try:
                         if not self._ensure_pacman_repo_packages(pm, combined_pkgs):
                             return
-                        pending_repo = getattr(self, "_pending_pacman_repo_packages", [])
+                        pending_repo = list(getattr(self, "_pending_pacman_repo_packages", []))
                     finally:
                         self._pacman_collect_only = False
                     if pending_repo:
                         combined_pkgs = _unique_preserve_order(combined_pkgs + pending_repo)
+                    # Standardlauf: validiert Repo-Pakete erneut mit aktivierter Automatisierung.
+                    if not self._ensure_pacman_repo_packages(pm, combined_pkgs):
+                        return
+                    if pending_repo:
                         self._pending_pacman_repo_packages = []
                 else:
                     if not self._ensure_pacman_repo_packages(pm, combined_pkgs):


### PR DESCRIPTION
## Summary
- `AutoTracker_GUI-v4.py` — `_installer_worker` (L1942-L1960): re-run `_ensure_pacman_repo_packages` after the collect-only probe, append pending repo packages to the batch, and only clear `_pending_pacman_repo_packages` once the standard guard succeeds.

## Testing
- `python -m compileall AutoTracker_GUI-v4.py`


------
https://chatgpt.com/codex/tasks/task_e_68d2bd4b72f48329b1365f10f1e561a4