### PR TITLE
AutoTracker: verhindere sudo-terminalprompt — dev_008

### DIFF
--- a/AutoTracker_GUI-v4.py
+++ b/AutoTracker_GUI-v4.py
@@ -462,6 +462,8 @@ def _prepare_arch_askpass_env(env=None):
         return None
     target_env = os.environ if env is None else env
     target_env["SUDO_ASKPASS"] = str(askpass_path)
+    # Stelle sicher, dass sudo nicht auf eine Terminal-Abfrage zurückfällt, sondern bei Bedarf abbricht.
+    target_env.setdefault("SUDO_ASKPASS_REQUIRE", "force")
     for key in ("DISPLAY", "WAYLAND_DISPLAY", "XAUTHORITY", "DBUS_SESSION_BUS_ADDRESS"):
         val = os.environ.get(key)
         if val and key not in target_env:


### PR DESCRIPTION
## Summary
- AutoTracker_GUI-v4.py: `_prepare_arch_askpass_env` (L462-L466) – setzt `SUDO_ASKPASS_REQUIRE=force`, damit sudo bei CachyOS/Arch nicht mehr auf Terminal-Passwortabfragen zurückfällt.

## Testing
- Ubuntu 22.04 (container): `python3 -m py_compile AutoTracker_GUI-v4.py`

Windows-spezifische Logik blieb unverändert.

------
https://chatgpt.com/codex/tasks/task_e_68d2c34d7be883298d7a5b176dd1d150